### PR TITLE
Changed to use game object name instead of mesh name

### DIFF
--- a/Exporters/Unity 5/Unity3D2Babylon/SceneBuilder.Meshes.cs
+++ b/Exporters/Unity 5/Unity3D2Babylon/SceneBuilder.Meshes.cs
@@ -39,9 +39,9 @@ namespace Unity3D2Babylon
             BabylonMesh babylonMesh = new BabylonMesh();
             var renderer = gameObject.GetComponent<Renderer>();
 
-            ExporterWindow.ReportProgress(progress, "Exporting mesh: " + mesh.name);
+            ExporterWindow.ReportProgress(progress, "Exporting mesh: " + gameObject.name);
 
-            babylonMesh.name = mesh.name;
+            babylonMesh.name = gameObject.name;
             babylonMesh.id = GetID(transform.gameObject);
             babylonMesh.receiveShadows = renderer.receiveShadows;
 

--- a/dist/preview release - alpha/what's new.md
+++ b/dist/preview release - alpha/what's new.md
@@ -21,6 +21,7 @@
     - Changes to meshes transform baking and added flipFaces [PR](https://github.com/BabylonJS/Babylon.js/pull/579) [jahow](https://github.com/jahow)
     - SerializeMesh serializes a mesh or array of meshes to be imported with the loader's ImportMesh. [PR](https://github.com/BabylonJS/Babylon.js/pull/583) [PR2](https://github.com/BabylonJS/Babylon.js/pull/609) [RaananW](https://github.com/RaananW)
 	- onCollide callback for meshes calling moveWithCollisions. [PR](https://github.com/BabylonJS/Babylon.js/pull/585) [RaananW](https://github.com/RaananW)
+	- Unity Exporter now uses game object name as the Babylon.js mesh name, instead of mesh name which is not unique when dealing with primitive objects (cubes, spheres, planes, etc..) [ozRocker] (https://github.com/punkoffice)
   - **Bug fixes**
     - Fixing bug with rig cameras positioning [deltakosh](https://github.com/deltakosh)
     - Instance meshes' geometry ID is now serialized correctly. [PR](https://github.com/BabylonJS/Babylon.js/pull/607) [RaananW](https://github.com/RaananW)


### PR DESCRIPTION
When creating a game object based off a primitive object (cube,
cylinder, plane, etc...) you would end up with the name of the primitive
object (mesh name) in the resulting .babylon file.  This presented
problems when trying to refer to an object.  For example, you would have
cubes all called "Cube" instead of the actual game object name.
